### PR TITLE
Fix release category typos

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,15 +9,15 @@ changelog:
     - title: 🐛 Bug Fixes
       labels:
       - bug
-    - title: ⚡️ Performance Improvments
+    - title: ⚡️ Performance Improvements
       labels:
       - performance
-    - title: 🗒️ Documentations
+    - title: 🗒️ Documentation
       labels:
       - documentation
     - title: 💄 UI Styles
       labels:
       - style
-    - title: Othre Changes
+    - title: Other Changes
       labels:
       - "*"


### PR DESCRIPTION
## Summary
- correct typos in `.github/release.yml` category titles

## Testing
- `git status --short`