### PR TITLE
Fix incorrect UniLog namespace

### DIFF
--- a/UniLogTweaks/UniLogTweaksMod.cs
+++ b/UniLogTweaks/UniLogTweaksMod.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using ResoniteHotReloadLib;
 #endif
 
-namespace EsnyaTweaks.UniLogeTweaks;
+namespace EsnyaTweaks.UniLogTweaks;
 
 /// <summary>
 /// Represents the UniLogTweaksMod which is a sealed class inheriting from ResoniteMod.

--- a/UniLogTweaks/UniLog_Patch.cs
+++ b/UniLogTweaks/UniLog_Patch.cs
@@ -2,7 +2,7 @@
 using Elements.Core;
 using HarmonyLib;
 
-namespace EsnyaTweaks.UniLogeTweaks;
+namespace EsnyaTweaks.UniLogTweaks;
 
 #pragma warning disable IDE0060
 


### PR DESCRIPTION
## Summary
- correct the namespace for `UniLogTweaksMod` and `UniLog_Patch`

## Testing
- `dotnet build EsnyaTweaks.sln -c Release` *(fails: Unable to load the service index for NuGet)*