### PR TITLE
Fix PhotonDust extension class spelling

### DIFF
--- a/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
@@ -7,7 +7,7 @@ using ResoniteModLoader;
 
 namespace EsnyaTweaks.PhotonDustTweaks;
 
-internal static class PhotonDustTweaksExntensions
+internal static class PhotonDustTweaksExtensions
 {
     private const string ADD_FROM_LABEL = "[Mod] Add modules from children";
     private const string REPLACE_FROM_LABEL = "[Mod] Replace modules from children";


### PR DESCRIPTION
## Summary
- rename `PhotonDustTweaksExntensions.cs` to `PhotonDustTweaksExtensions.cs`
- correct the class name to `PhotonDustTweaksExtensions`

## Testing
- `dotnet build -v q` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*