### PR TITLE
Fix PhotonDustTweaks extension class typo

### DIFF
--- a/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
@@ -7,7 +7,7 @@ using ResoniteModLoader;
 
 namespace EsnyaTweaks.PhotonDustTweaks;
 
-internal static class PhotonDustTweaksExntensions
+internal static class PhotonDustTweaksExtensions
 {
     private const string ADD_FROM_LABEL = "[Mod] Add modules from children";
     private const string REPLACE_FROM_LABEL = "[Mod] Replace modules from children";


### PR DESCRIPTION
## Summary
- rename PhotonDustTweaksExntensions.cs to PhotonDustTweaksExtensions.cs
- update class name to `PhotonDustTweaksExtensions`

## Testing
- `dotnet build EsnyaTweaks.sln -v minimal` *(fails: Unable to load the service index for NuGet - no route to host)*