### PR TITLE
codex/test-context-guard

### DIFF
--- a/FluxLoopTweaks.Tests/FluxLoopPatchExecutionTests.cs
+++ b/FluxLoopTweaks.Tests/FluxLoopPatchExecutionTests.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using FrooxEngine.ProtoFlux;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using ProtoFlux.Runtimes.Execution.Nodes;
+using Xunit;
+
+namespace EsnyaTweaks.FluxLoopTweaks.Tests;
+
+public class FluxLoopPatchExecutionTests
+{
+    [Fact]
+    public void While_Prefix_Should_Not_Run_For_Unsupported_Context()
+    {
+        var loop = new While();
+        var context = new ExecutionContext();
+        IOperation? result = null;
+
+        var executed = false;
+        loop.LoopStart.ExecuteAction = _ => executed = true;
+
+        var ret = While_Run_Patch.Prefix(loop, context, ref result);
+
+        ret.Should().BeTrue();
+        executed.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void While_Prefix_Should_Run_Loop()
+    {
+        var iterations = 0;
+        var loop = new While
+        {
+            LoopStart = new Call { ExecuteAction = _ => { } },
+            Condition = new ValueInput<bool>(_ => iterations++ < 2),
+            LoopIteration = new Call { ExecuteAction = _ => { } },
+            LoopEnd = new Continuation { Target = new DummyOperation() },
+            Runtime = new DummyRuntime(),
+        };
+        var context = new FrooxEngineContext();
+        IOperation? result = null;
+
+        var ret = While_Run_Patch.Prefix(loop, context, ref result);
+
+        ret.Should().BeFalse();
+        iterations.Should().Be(2);
+        result.Should().Be(loop.LoopEnd.Target);
+    }
+
+    [Fact]
+    public async Task AsyncWhile_Prefix_Should_Run_Loop()
+    {
+        var iterations = 0;
+        var asyncWhile = new AsyncWhile
+        {
+            LoopStart = new AsyncCall { ExecuteAsyncFunc = _ => Task.CompletedTask },
+            Condition = new ValueInput<bool>(_ => iterations++ < 2),
+            LoopIteration = new AsyncCall { ExecuteAsyncFunc = _ => Task.CompletedTask },
+            LoopEnd = new Continuation { Target = new DummyOperation() },
+            Runtime = new DummyRuntime(),
+        };
+        var context = new FrooxEngineContext();
+        Task<IOperation>? result = null;
+
+        var ret = AsyncWhile_RunAsync_Patch.Prefix(asyncWhile, context, ref result);
+
+        ret.Should().BeFalse();
+        var op = await result!;
+        iterations.Should().Be(2);
+        op.Should().Be(asyncWhile.LoopEnd.Target);
+    }
+
+    private class DummyRuntime : IExecutionRuntime { }
+}

--- a/FluxLoopTweaks.Tests/FluxLoopTweaks.Tests.csproj
+++ b/FluxLoopTweaks.Tests/FluxLoopTweaks.Tests.csproj
@@ -1,5 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluxLoopTweaks\FluxLoopTweaks.csproj" />
+    <Compile Include="..\FluxLoopTweaks\While_Run_Patch.cs" Link="While_Run_Patch.cs" />
+    <Compile
+      Include="..\FluxLoopTweaks\AsyncWhile_RunAsync_Patch.cs"
+      Link="AsyncWhile_RunAsync_Patch.cs"
+    />
+    <Compile Include="TestStubs.cs" />
   </ItemGroup>
 </Project>

--- a/FluxLoopTweaks.Tests/TestStubs.cs
+++ b/FluxLoopTweaks.Tests/TestStubs.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ProtoFlux.Core
+{
+    public interface IOperation { }
+
+    public class DummyOperation : IOperation { }
+}
+
+namespace ProtoFlux.Runtimes.Execution
+{
+    public interface IExecutionRuntime { }
+
+    public class ExecutionContext
+    {
+        public bool AbortExecution { get; set; }
+    }
+
+    public class ExecutionAbortedException : Exception
+    {
+        public ExecutionAbortedException(
+            IExecutionRuntime? runtime,
+            object node,
+            ProtoFlux.Core.IOperation operation,
+            bool isAsync
+        ) { }
+    }
+}
+
+namespace FrooxEngine.ProtoFlux
+{
+    public class Engine
+    {
+        public int UpdateTick { get; set; }
+    }
+
+    public class FrooxEngineContext : ProtoFlux.Runtimes.Execution.ExecutionContext
+    {
+        public Engine Engine { get; } = new();
+    }
+}
+
+namespace ProtoFlux.Runtimes.Execution.Nodes
+{
+    using FrooxEngine.ProtoFlux;
+    using ProtoFlux.Core;
+    using ProtoFlux.Runtimes.Execution;
+
+    public class ValueInput<T>
+    {
+        private readonly Func<ExecutionContext, T> _func;
+
+        public ValueInput(Func<ExecutionContext, T> func) => _func = func;
+
+        public T Evaluate(ExecutionContext context, bool defaultValue) => _func(context);
+    }
+
+    public class Call
+    {
+        public Action<ExecutionContext>? ExecuteAction { get; set; }
+        public IOperation Target { get; set; } = new DummyOperation();
+
+        public void Execute(ExecutionContext context) => ExecuteAction?.Invoke(context);
+    }
+
+    public class AsyncCall
+    {
+        public Func<FrooxEngineContext, Task>? ExecuteAsyncFunc { get; set; }
+        public IOperation Target { get; set; } = new DummyOperation();
+
+        public Task ExecuteAsync(FrooxEngineContext context) =>
+            ExecuteAsyncFunc?.Invoke(context) ?? Task.CompletedTask;
+    }
+
+    public class Continuation
+    {
+        public IOperation Target { get; set; } = new DummyOperation();
+    }
+
+    public class While
+    {
+        public Call LoopStart { get; set; } = new();
+        public ValueInput<bool> Condition { get; set; } = new(_ => false);
+        public Call LoopIteration { get; set; } = new();
+        public Continuation LoopEnd { get; set; } = new();
+        public IExecutionRuntime Runtime { get; set; } = null!;
+    }
+
+    public class AsyncWhile
+    {
+        public ValueInput<bool> Condition { get; set; } = new(_ => false);
+        public AsyncCall LoopStart { get; set; } = new();
+        public AsyncCall LoopIteration { get; set; } = new();
+        public Continuation LoopEnd { get; set; } = new();
+        public IExecutionRuntime Runtime { get; set; } = null!;
+    }
+}
+
+namespace ResoniteModLoader
+{
+    public class ResoniteMod
+    {
+        public virtual object? GetConfiguration() => null;
+
+        public static void Warn(string message) { }
+    }
+
+    public interface ModConfiguration
+    {
+        T GetValue<T>(ModConfigurationKey<T> key);
+    }
+
+    public class ModConfigurationKey<T>
+    {
+        public ModConfigurationKey(string name, string description, Func<T> computeDefault) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class AutoRegisterConfigKeyAttribute : Attribute { }
+}
+
+namespace HarmonyLib
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public class HarmonyPatch : Attribute
+    {
+        public HarmonyPatch(Type type, string methodName)
+        {
+            info = new PatchInfo { declaringType = type, methodName = methodName };
+        }
+
+        public PatchInfo info { get; }
+
+        public class PatchInfo
+        {
+            public Type? declaringType;
+            public string? methodName;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HarmonyPrefix : Attribute { }
+}
+
+namespace EsnyaTweaks.FluxLoopTweaks
+{
+    public partial class FluxLoopTweaksMod
+    {
+        public static int TimeoutMs { get; set; } = 1000;
+    }
+}


### PR DESCRIPTION
## Summary
- add execution tests for FluxLoopTweaks using stubbed runtime
- remove unused `PrefixContextChecks` tests
- target `net8.0` for test project

## Testing
- `dotnet csharpier check .`
- `dotnet test FluxLoopTweaks.Tests/FluxLoopTweaks.Tests.csproj` *(fails: NU1301 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6840177fe82c832a8d72463535f78c64