### PR TITLE
Add UniLog patch behavior tests

### DIFF
--- a/UniLogTweaks.Tests/UniLog_PatchBehaviorTests.cs
+++ b/UniLogTweaks.Tests/UniLog_PatchBehaviorTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace EsnyaTweaks.UniLogTweaks.Tests;
+
+public static class UniLog_PatchBehaviorTests
+{
+    private static Type GetPatchType() =>
+        typeof(UniLogTweaksMod).Assembly.GetType("EsnyaTweaks.UniLogTweaks.UniLog_Patch", true)!;
+
+    [Fact]
+    public static void Patch_Should_Add_Indent_And_Disable_StackTrace()
+    {
+        var patch = GetPatchType()
+            .GetMethod("Patch", BindingFlags.Static | BindingFlags.NonPublic)!;
+        object[] args = { "line1\nline2", true, false };
+        patch.Invoke(null, args);
+
+        args[0].Should().Be("line1\n\tline2");
+        args[1].Should().Be(false);
+    }
+
+    [Fact]
+    public static void Patch_Should_Leave_Message_When_No_Newline()
+    {
+        var patch = GetPatchType()
+            .GetMethod("Patch", BindingFlags.Static | BindingFlags.NonPublic)!;
+        const string original = "single line";
+        object[] args = { original, true, true };
+        patch.Invoke(null, args);
+
+        args[0].Should().Be(original);
+        args[1].Should().Be(true);
+    }
+}

--- a/UniLogTweaks.Tests/UniLog_PatchTests.cs
+++ b/UniLogTweaks.Tests/UniLog_PatchTests.cs
@@ -10,7 +10,10 @@ public static class UniLog_PatchTests
 {
     private static System.Type GetPatchType()
     {
-        return typeof(UniLogTweaksMod).Assembly.GetType("EsnyaTweaks.UniLogTweaks.UniLog_Patch", true)!;
+        return typeof(UniLogTweaksMod).Assembly.GetType(
+            "EsnyaTweaks.UniLogTweaks.UniLog_Patch",
+            true
+        )!;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- increase test coverage by adding behavior tests for UniLog patch
- format files with csharpier

## Testing
- `dotnet csharpier format .`
- `dotnet csharpier check .`
- ❌ `dotnet test --no-build --verbosity normal` *(fails: The argument <...>.exe is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68402340632c832a80076977b7048d75