### PR TITLE
Add more LODGroup patch tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,5 +24,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />
     <PackageVersion Include="xunit.v3.runner.inproc.console" Version="2.0.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- extend `WorkerInspector_BuildInspectorUI_PatchTests` to inspect method bodies using Roslyn
- add Roslyn package version to central package list

## Testing
- `dotnet csharpier format .`
- `dotnet csharpier check .`

------
https://chatgpt.com/codex/tasks/task_e_6840255b96b0832a881f3339800e884b