### PR TITLE
chore: upgrade setup to .NET 9.0 and add maintenance script

### DIFF
--- a/.codex/maintenance.sh
+++ b/.codex/maintenance.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+export PATH="$PATH:$HOME/.dotnet/tools"
+
+# Refresh local tools
+if command -v dotnet >/dev/null; then
+  dotnet tool restore || true
+  dotnet restore || true
+fi

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-# Ensure dotnet is available
-if ! command -v dotnet sdk check >/dev/null; then
-  apt update && apt install -y --no-install-recommends dotnet-sdk-8.0 # Replace by 9.0 when Codex image updated
+# Ensure .NET 9 SDK is available
+if ! dotnet --list-sdks 2>/dev/null | grep -q '^9\.'; then
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
 fi
 
-export PATH="$PATH:$HOME/.dotnet/tools"
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
 
 # Restore local tools
 dotnet tool restore || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 The CI workflow uses static checks that do not require Resonite assemblies.
 
+## Environment Setup
+
+- Target .NET SDK 9.0.
+- `.codex/setup.sh` installs the SDK and restores tools and dependencies.
+- `.codex/maintenance.sh` refreshes tools and dependencies after cache restoration.
+
 ## Coding Standards
 
 - Stay DRY, but avoid premature abstraction.


### PR DESCRIPTION
## Summary
- install .NET 9 SDK during setup
- add maintenance script to refresh tools and dependencies
- document environment scripts in AGENTS.md

## Testing
- `dotnet format --verify-no-changes` *(fails: Could not find Resonite assemblies)*
- `dotnet test` *(fails: missing Resonite references)*

------
https://chatgpt.com/codex/tasks/task_e_68c2736d4144832ab41b0ffc6c400db7