### PR TITLE
fix: persist DOTNET_ROOT and unify PATH

### DIFF
--- a/.codex/dotnet-env.sh
+++ b/.codex/dotnet-env.sh
@@ -1,0 +1,3 @@
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+

--- a/.codex/maintenance.sh
+++ b/.codex/maintenance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export PATH="$PATH:$HOME/.dotnet/tools"
+source "$(dirname "$0")/dotnet-env.sh"
 
 # Refresh local tools
 if command -v dotnet >/dev/null; then

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -2,12 +2,24 @@
 set -euo pipefail
 
 # Ensure .NET 9 SDK is available
-if ! dotnet --list-sdks 2>/dev/null | grep -q '^9\.'; then
+if ! (command -v dotnet >/dev/null && dotnet --list-sdks 2>/dev/null | grep -q '^9\.') ; then
   curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
 fi
 
-export DOTNET_ROOT="$HOME/.dotnet"
-export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+env_file="$(dirname "$0")/dotnet-env.sh"
+source "$env_file"
+
+if [ -n "${GITHUB_PATH:-}" ]; then
+  {
+    echo "$DOTNET_ROOT"
+    echo "$DOTNET_ROOT/tools"
+  } >> "$GITHUB_PATH"
+else
+  profile="$HOME/.bashrc"
+  if ! grep -Fq '.dotnet' "$profile" 2>/dev/null; then
+    cat "$env_file" >> "$profile"
+  fi
+fi
 
 # Restore local tools
 dotnet tool restore || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 - Target .NET SDK 9.0.
 - `.codex/setup.sh` installs the SDK and restores tools and dependencies.
 - `.codex/maintenance.sh` refreshes tools and dependencies after cache restoration.
+- `.codex/dotnet-env.sh` defines `DOTNET_ROOT` and `PATH` for both scripts.
 
 ## Coding Standards
 


### PR DESCRIPTION
## Summary
- factor shared dotnet PATH setup into `.codex/dotnet-env.sh`
- persist dotnet installation for later steps in `setup.sh`
- source shared PATH setup from `maintenance.sh`

## Testing
- `dotnet format --verify-no-changes` *(fails: type or namespace name 'IWorldElement' could not be found)*
- `dotnet test` *(fails: type or namespace name 'HarmonyPatchAttribute' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2768a1f60832aafdfac0b3ab20e45