### PR TITLE
fix: add InventoryUITweaks tests and reflection validation

### DIFF
--- a/InventoryUITweaks.Tests/InventoryUITweaks.Tests.csproj
+++ b/InventoryUITweaks.Tests/InventoryUITweaks.Tests.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\InventoryUITweaks\InventoryUITweaks.csproj" />
+  </ItemGroup>
+</Project>

--- a/InventoryUITweaks.Tests/ReflectionCacheTests.cs
+++ b/InventoryUITweaks.Tests/ReflectionCacheTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace EsnyaTweaks.InventoryUITweaks.Tests;
+
+public class ReflectionCacheTests
+{
+    [Fact]
+    public void DirectoryField_ShouldExist()
+    {
+        Assert.NotNull(ReflectionCache.InventoryItemUI_Directory);
+    }
+}

--- a/InventoryUITweaks/InventoryUITweaksMod.cs
+++ b/InventoryUITweaks/InventoryUITweaksMod.cs
@@ -36,8 +36,8 @@ public class InventoryUITweaksMod : ResoniteMod
             {
                 var plusIndex = informationalVersion.IndexOf('+', System.StringComparison.Ordinal);
                 return plusIndex >= 0
-                    ? informationalVersion![..plusIndex]
-                    : informationalVersion!;
+                    ? informationalVersion[..plusIndex]
+                    : informationalVersion;
             }
             return ModAssembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? "0.0.0";
         }

--- a/InventoryUITweaks/Patches.cs
+++ b/InventoryUITweaks/Patches.cs
@@ -50,7 +50,17 @@ internal static class ReflectionCache
     );
 
     // Fields for runtime checks
-    internal static readonly FieldInfo InventoryItemUI_Directory = AccessTools.Field(typeof(InventoryItemUI), "Directory");
+    internal static readonly FieldInfo InventoryItemUI_Directory;
+
+    static ReflectionCache()
+    {
+        InventoryItemUI_Directory = AccessTools.Field(typeof(InventoryItemUI), "Directory");
+        if (InventoryItemUI_Directory == null)
+        {
+            Console.WriteLine("[InventoryUITweaks] Error: Could not find field 'Directory' on InventoryItemUI. Reflection access failed.");
+            throw new MissingFieldException(nameof(InventoryItemUI), "Directory");
+        }
+    }
 
     // FavoriteEntity reflection (type and method)
     internal static readonly Type FavoriteEntityType = AccessTools.TypeByName("SkyFrost.Base.FavoriteEntity");
@@ -96,7 +106,7 @@ internal static class BrowserItem_Pressed_Patch
         // Single-click open only for folders (InventoryItemUI with non-null Directory)
         if (__instance is InventoryItemUI inv)
         {
-            var dir = ReflectionCache.InventoryItemUI_Directory?.GetValue(inv);
+            var dir = ReflectionCache.InventoryItemUI_Directory.GetValue(inv);
             if (dir != null)
             {
                 inv.Browser.Target.SelectedItem.Target = null!;
@@ -119,7 +129,7 @@ internal static class InventoryBrowser_ProcessItem_Postfix
         {
             return;
         }
-        var isDirectory = ReflectionCache.InventoryItemUI_Directory?.GetValue(item) != null;
+        var isDirectory = ReflectionCache.InventoryItemUI_Directory.GetValue(item) != null;
         var slot = item.Slot;
         if (slot == null || slot.IsDestroyed)
         {
@@ -231,7 +241,7 @@ internal static class InventoryBrowser_OnItemSelected_Postfix
         __instance.Slot.GetComponentsInChildren(items);
         foreach (var it in items)
         {
-            var isDir = ReflectionCache.InventoryItemUI_Directory?.GetValue(it) != null;
+            var isDir = ReflectionCache.InventoryItemUI_Directory.GetValue(it) != null;
             if (!isDir)
                 continue;
             var helperSlot = it.Slot.FindChild("ET_SelectFolderButton");


### PR DESCRIPTION
## Summary
- validate `InventoryItemUI.Directory` reflection field on start and assume its presence
- drop redundant null-forgiving operators in version parsing
- add missing `InventoryUITweaks.Tests` project with coverage for reflection lookup

## Testing
- ⚠️ `dotnet format --verify-no-changes --no-restore`
- ⚠️ `dotnet build -c Debug -v:minimal -p:ResonitePath=tmp/ResoniteReferences`
- ⚠️ `dotnet test -c Debug -v:minimal -p:ResonitePath=tmp/ResoniteReferences`


------
https://chatgpt.com/codex/tasks/task_e_68c28dc917c4832a88b93dbee79fe75e