### PR TITLE
Address review feedback for hot reload fetching and directory field safety

### DIFF
--- a/.codex/hotreload-lib.sh
+++ b/.codex/hotreload-lib.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+ensure_hot_reload_libs() {
+  local res_dir="$1"
+  if [ ! -f "$res_dir/ResoniteHotReloadLib.dll" ] || [ ! -f "$res_dir/ResoniteHotReloadLibCore.dll" ]; then
+    local release_json="$(curl -s https://api.github.com/repos/Nytra/ResoniteHotReloadLib/releases/latest)"
+    local url="$(echo "$release_json" | jq -r '.assets[] | select(.name | test("^ResoniteHotReloadLib.*\\.RML\\.zip$")) | .browser_download_url')"
+    if [ -z "$url" ] || [ "$url" = "null" ]; then
+      echo "Error: Could not find ResoniteHotReloadLib RML zip asset in the latest release." >&2
+      return 1
+    fi
+    local tmp_zip="$res_dir/HotReloadLib.RML.zip"
+    curl -L "$url" -o "$tmp_zip"
+    unzip -j -o "$tmp_zip" ResoniteHotReloadLib.dll ResoniteHotReloadLibCore.dll -d "$res_dir"
+    rm "$tmp_zip"
+  fi
+}

--- a/.codex/maintenance.sh
+++ b/.codex/maintenance.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 source "$(dirname "$0")/dotnet-env.sh"
+source "$(dirname "$0")/hotreload-lib.sh"
 
 # Refresh local tools
 if command -v dotnet >/dev/null; then
@@ -17,13 +18,6 @@ if command -v dotnet >/dev/null; then
         curl -L "$url" -o "$RES_DIR/$asset"
       done
     fi
-    if [ ! -f "$RES_DIR/ResoniteHotReloadLib.dll" ] || [ ! -f "$RES_DIR/ResoniteHotReloadLibCore.dll" ]; then
-      release_json="$(curl -s https://api.github.com/repos/Nytra/ResoniteHotReloadLib/releases/latest)"
-      url="$(echo "$release_json" | jq -r '.assets[] | select(.name | endswith("RML.zip")) | .browser_download_url')"
-      tmp_zip="$RES_DIR/HotReloadLib.RML.zip"
-      curl -L "$url" -o "$tmp_zip"
-      unzip -j -o "$tmp_zip" ResoniteHotReloadLib.dll ResoniteHotReloadLibCore.dll -d "$RES_DIR"
-      rm "$tmp_zip"
-    fi
+    ensure_hot_reload_libs "$RES_DIR"
   fi
 fi

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -8,6 +8,7 @@ fi
 
 env_file="$(dirname "$0")/dotnet-env.sh"
 source "$env_file"
+source "$(dirname "$0")/hotreload-lib.sh"
 
 if [ -n "${GITHUB_PATH:-}" ]; then
   {
@@ -38,12 +39,5 @@ if [ ! -f "$RES_DIR/FrooxEngine.dll" ]; then
       curl -L "$url" -o "$RES_DIR/$asset"
     done
   fi
-  if [ ! -f "$RES_DIR/ResoniteHotReloadLib.dll" ] || [ ! -f "$RES_DIR/ResoniteHotReloadLibCore.dll" ]; then
-    release_json="$(curl -s https://api.github.com/repos/Nytra/ResoniteHotReloadLib/releases/latest)"
-    url="$(echo "$release_json" | jq -r '.assets[] | select(.name | endswith("RML.zip")) | .browser_download_url')"
-    tmp_zip="$RES_DIR/HotReloadLib.RML.zip"
-    curl -L "$url" -o "$tmp_zip"
-    unzip -j -o "$tmp_zip" ResoniteHotReloadLib.dll ResoniteHotReloadLibCore.dll -d "$RES_DIR"
-    rm "$tmp_zip"
-  fi
+  ensure_hot_reload_libs "$RES_DIR"
 fi


### PR DESCRIPTION
## Summary
- guard `InventoryItemUI.Directory` reflection lookups with null-aware helper
- centralize hot reload library download logic with stricter asset validation

## Testing
- `dotnet format --verify-no-changes --no-restore` *(fails: The server disconnected unexpectedly)*
- `dotnet build -c Debug -v:minimal`
- `dotnet test -c Debug -v:minimal` *(fails: MSB4017 unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d14dfb20832a8b81aa7ba1db4a8b