### PR TITLE
refactor: centralize UIBuilder LocalButton helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 ## Coding Standards
 
 - Stay DRY, but avoid premature abstraction.
+- For UIBuilder buttons with local actions, use `UIX/UIBuilderExtensions.LocalButton` instead of defining per-project helpers.
 - Prefer pure functions, immutability, and declarative style.
 - Good naming & structure > comments; comment only non-obvious WHY
 - Keep code self-explanatory.

--- a/AssetOptimizationTweaks/AssetOptimizationExtensions.cs
+++ b/AssetOptimizationTweaks/AssetOptimizationExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Elements.Core;
 using FrooxEngine;
-using FrooxEngine.UIX;
 using ResoniteModLoader;
 
 namespace EsnyaTweaks.AssetOptimizationTweaks;
@@ -220,14 +219,4 @@ internal static class AssetOptimizationExtensions
         return false;
     }
 
-    public static Button LocalButton(
-        this UIBuilder ui,
-        string label,
-        ButtonEventHandler localAction
-    )
-    {
-        var button = ui.Button(label);
-        button.LocalPressed += localAction;
-        return button;
-    }
 }

--- a/AssetOptimizationTweaks/AssetOptimizationTweaks.csproj
+++ b/AssetOptimizationTweaks/AssetOptimizationTweaks.csproj
@@ -1,1 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk"></Project>
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="../UIX/UIBuilderExtensions.cs" Link="UIBuilderExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/AssetOptimizationTweaks/AssetOptimizationWizard_OnAttach_Patch.cs
+++ b/AssetOptimizationTweaks/AssetOptimizationWizard_OnAttach_Patch.cs
@@ -3,6 +3,7 @@ using FrooxEngine;
 using FrooxEngine.UIX;
 using HarmonyLib;
 using ResoniteModLoader;
+using EsnyaTweaks.UIX;
 
 namespace EsnyaTweaks.AssetOptimizationTweaks;
 

--- a/PhotonDustTweaks/PhotonDustTweaks.csproj
+++ b/PhotonDustTweaks/PhotonDustTweaks.csproj
@@ -1,1 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"></Project>
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="../UIX/UIBuilderExtensions.cs" Link="UIBuilderExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksExtensions.cs
@@ -4,6 +4,7 @@ using FrooxEngine;
 using FrooxEngine.PhotonDust;
 using FrooxEngine.UIX;
 using ResoniteModLoader;
+using EsnyaTweaks.UIX;
 
 namespace EsnyaTweaks.PhotonDustTweaks;
 
@@ -19,16 +20,6 @@ internal static class PhotonDustTweaksExtensions
     {
         ui.LocalButton(ADD_TO_LABEL, (button, _) => module.AddToStyle(button));
         ui.LocalButton(REMOVE_FROM_LABEL, (button, _) => module.RemoveFromStyle(button));
-    }
-
-    public static void LocalButton(
-        this UIBuilder ui,
-        in string label,
-        ButtonEventHandler localAction
-    )
-    {
-        var button = ui.Button(label);
-        button.LocalPressed += localAction;
     }
 
     public static void AddToStyle(this IParticleSystemSubsystem module, IButton button)

--- a/UIX/UIBuilderExtensions.cs
+++ b/UIX/UIBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using FrooxEngine;
+using FrooxEngine.UIX;
+
+namespace EsnyaTweaks.UIX;
+
+internal static class UIBuilderExtensions
+{
+    internal static Button LocalButton(
+        this UIBuilder ui,
+        string label,
+        ButtonEventHandler localAction
+    )
+    {
+        var button = ui.Button(label);
+        button.LocalPressed += localAction;
+        return button;
+    }
+}

--- a/docs/notes/ui-builder-local-button.md
+++ b/docs/notes/ui-builder-local-button.md
@@ -1,0 +1,20 @@
+# Design Note: Shared LocalButton UIBuilder extension
+
+## Purpose
+Provide a reusable extension method to create UI buttons that fire `LocalPressed` handlers without repeating boilerplate across mods.
+
+## Boundaries
+- Applies to UIBuilder-based inspectors needing local action wiring.
+- Covers only the `LocalButton` helper; additional UI helpers may be added later if necessary.
+
+## Public API
+- `Button UIBuilderExtensions.LocalButton(this UIBuilder ui, string label, ButtonEventHandler localAction)`
+
+## Dependencies
+- FrooxEngine.UIX types (`UIBuilder`, `Button`, `ButtonEventHandler`).
+
+## Tests
+- Exercised indirectly by existing build and test commands.
+
+## Migration
+- Replace per-project `LocalButton` implementations with the shared extension.


### PR DESCRIPTION
## Summary
- document shared LocalButton extension and how to use it
- centralize LocalButton helper and update mods to call it

## Testing
- `dotnet format --verify-no-changes --no-restore` *(fails: ResoniteHotReloadLib missing)*
- `dotnet build -c Debug -v:minimal` *(fails: HotReloader reference missing)*
- `dotnet test -c Debug -v:minimal` *(fails: HotReloader reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d08f2818832aba3a050f87d71f31