### PR TITLE
Handle null messages in UniLog patch

### DIFF
--- a/UniLogTweaks.Tests/UniLog_PatchBehaviorTests.cs
+++ b/UniLogTweaks.Tests/UniLog_PatchBehaviorTests.cs
@@ -39,4 +39,18 @@ public static class UniLog_PatchBehaviorTests
         args[0].Should().Be(original);
         args[1].Should().Be(true);
     }
+
+    [Fact]
+    public static void Patch_Should_Handle_Null_Message()
+    {
+        var patch = GetPatchType()
+            .GetMethod("Patch", BindingFlags.Static | BindingFlags.NonPublic)!;
+        object?[] args = [null, true, true];
+
+        var act = () => patch.Invoke(null, args);
+
+        act.Should().NotThrow();
+        args[0].Should().Be(string.Empty);
+        args[1].Should().Be(true);
+    }
 }

--- a/UniLogTweaks/UniLog_Patch.cs
+++ b/UniLogTweaks/UniLog_Patch.cs
@@ -14,7 +14,7 @@ internal static class UniLog_Patch
     {
         if (UniLogTweaksMod.AddIndent)
         {
-            message = message.Replace("\n", "\n\t", System.StringComparison.Ordinal);
+            message = message is null ? string.Empty : message.Replace("\n", "\n\t", System.StringComparison.Ordinal);
         }
 
         if (!allowStackTrace)

--- a/docs/adr/0002-unilog-null-message.md
+++ b/docs/adr/0002-unilog-null-message.md
@@ -1,0 +1,14 @@
+# ADR 0002: Guard UniLog patch against null messages
+
+## Status
+Accepted
+
+## Context
+The UniLog patch indents multi-line messages by replacing newline characters. When the incoming message is null, calling `Replace` throws a null reference exception.
+
+## Decision
+Add a null check before performing the replacement. If the message is null and indentation is enabled, set it to an empty string.
+
+## Consequences
+- Logging hooks no longer throw when given null messages.
+- Tests cover the null message scenario to prevent regression.


### PR DESCRIPTION
## Summary
- guard UniLog patches against null messages
- test patch behavior with null input
- document null-handling decision

## Testing
- `dotnet format --verify-no-changes --no-restore --verbosity diagnostic --include UniLogTweaks/UniLog_Patch.cs`
- `dotnet format --verify-no-changes --no-restore --verbosity diagnostic --include UniLogTweaks.Tests/UniLog_PatchBehaviorTests.cs`
- `dotnet build UniLogTweaks/UniLogTweaks.csproj -c Release -v:minimal -p:ResonitePath="/root/.nuget/packages/resonite.gamelibs/2025.9.2.430/ref/net9.0"`
- `dotnet test UniLogTweaks.Tests/UniLogTweaks.Tests.csproj -c Release -v:minimal -p:ResonitePath="/root/.nuget/packages/resonite.gamelibs/2025.9.2.430/ref/net9.0"` *(fails: Could not load file or assembly 'FrooxEngine' version 2025.8.20.1298)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d09724f8832aa2334333036e7325