### PR TITLE
fix: deduplicate asset redirection map

### DIFF
--- a/AssetOptimizationTweaks/AssetOptimizationExtensions.cs
+++ b/AssetOptimizationTweaks/AssetOptimizationExtensions.cs
@@ -82,7 +82,7 @@ internal static class AssetOptimizationExtensions
             foreach (var (original, duplicate) in duplicatePairs)
             {
                 AddSyncMemberRedirections(redirectionMap, duplicate, original);
-                redirectionMap.Add(duplicate, original);
+                redirectionMap.TryAdd(duplicate, original);
             }
         }
     }
@@ -132,7 +132,13 @@ internal static class AssetOptimizationExtensions
                 ResoniteMod.DebugFunc(() =>
                     $"Redirecting reference from {duplicateMember} to {originalMember}"
                 );
-                redirectionMap.Add(duplicateMember, originalMember);
+                if (!redirectionMap.TryAdd(duplicateMember, originalMember)
+                    && redirectionMap[duplicateMember] != originalMember)
+                {
+                    ResoniteMod.DebugFunc(() =>
+                        $"Duplicate redirection detected for {duplicateMember}; existing target {redirectionMap[duplicateMember]} kept over {originalMember}"
+                    );
+                }
             }
         }
     }

--- a/docs/adr/0002-redirection-map-deduplication.md
+++ b/docs/adr/0002-redirection-map-deduplication.md
@@ -1,0 +1,13 @@
+# 0002 Redirection Map Deduplication
+
+## Status
+Accepted
+
+## Context
+`AssetOptimizationExtensions` built a redirection map using `Dictionary.Add`. Reprocessing the same components caused duplicate key exceptions.
+
+## Decision
+Use `Dictionary.TryAdd` and explicit checks for existing keys when building redirection maps and adding sync member redirections. This makes deduplication idempotent and avoids exceptions.
+
+## Consequences
+Duplicate entries are ignored; existing mappings take precedence and are preserved.


### PR DESCRIPTION
## Summary
- ensure redirection map and sync member mapping ignore duplicates
- guard against repeated processing with explicit duplicate checks
- document decision in ADR

## Testing
- `dotnet format AssetOptimizationTweaks/AssetOptimizationTweaks.csproj --verify-no-changes --no-restore` *(fails: ResoniteHotReloadLib missing)*
- `dotnet format AssetOptimizationTweaks.Tests/AssetOptimizationTweaks.Tests.csproj --verify-no-changes --no-restore`
- `dotnet build -c Debug -v:minimal` *(fails: ResoniteHotReloadLib missing)*
- `dotnet build -c Release -v:minimal`
- `dotnet test AssetOptimizationTweaks.Tests/AssetOptimizationTweaks.Tests.csproj -c Release -v:minimal` *(fails: FrooxEngine missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d09d8594832aa4baca228fd9248c