### PR TITLE
Reduce analyzer suppressions across mods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -70,6 +70,7 @@ dotnet_diagnostic.CA1707.severity = none  # test classes often don't follow nami
 # StyleCop: configure per rule (base off)
 dotnet_analyzer_diagnostic.category-StyleCop.severity = none
 dotnet_diagnostic.SA1649.severity = error
+dotnet_diagnostic.SA1111.severity = warning
 
 # StyleCop exclusions (repo policy)
 # - File header/element docs are not required; keep code concise
@@ -87,7 +88,6 @@ dotnet_diagnostic.SA1107.severity = none  # multiple statements on one line
 dotnet_diagnostic.SA1202.severity = none  # member order rules
 dotnet_diagnostic.SA1311.severity = none  # static readonly fields casing
 dotnet_diagnostic.SA1009.severity = none  # closing parenthesis spacing
-dotnet_diagnostic.SA1111.severity = none  # closing parenthesis should be on line of last parameter
 dotnet_diagnostic.SA1512.severity = none  # single-line comments should not be followed by blank line
 dotnet_diagnostic.SA1402.severity = none  # file may only contain a single type
 dotnet_diagnostic.SA1516.severity = none  # elements should be separated by blank line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 - Prefer pure functions, immutability, and declarative style.
 - Good naming & structure > comments; comment only non-obvious WHY
 - Keep code self-explanatory.
+- Order members from most to least accessible and ensure each file ends with exactly one trailing newline; place closing parentheses on the line of the last parameter.
 
 ## UIBuilder Guidelines (Must)
 
@@ -62,6 +63,8 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 
 - Warnings policy:
   - Zero-warnings baseline（Must）: ビルド時の警告は許容しない。既存・新規とも修正し、抑制は最小限（やむを得ないシグネチャのみ）。
+  - Prefer adjusting signatures or accessibility to eliminate warnings before using `SuppressMessage` or `#pragma`.
+  - Harmony magic parameter names (e.g., `__instance`, `__result`) may use `[SuppressMessage("Style", "SA1313")]` with justification.
 
 - Commit hygiene:
   - Use Conventional Commit + gitmoji. One concise subject line per commit.

--- a/Common/Helpers/AssemblyMetadata.cs
+++ b/Common/Helpers/AssemblyMetadata.cs
@@ -38,4 +38,3 @@ public static class AssemblyMetadata
         return (name, author, version!, link);
     }
 }
-

--- a/Common/Mod/EsnyaResoniteMod.cs
+++ b/Common/Mod/EsnyaResoniteMod.cs
@@ -9,11 +9,6 @@ namespace EsnyaTweaks.Common.Modding;
 /// </summary>
 public abstract class EsnyaResoniteMod : ResoniteMod
 {
-    /// <summary>
-    /// The module assembly (derived type's assembly).
-    /// </summary>
-    protected Assembly ModAssembly => GetType().Assembly;
-
     /// <inheritdoc/>
     public override string Name => AssemblyMetadata.Read(ModAssembly).Name;
 
@@ -25,5 +20,9 @@ public abstract class EsnyaResoniteMod : ResoniteMod
 
     /// <inheritdoc/>
     public override string Link => AssemblyMetadata.Read(ModAssembly).Link;
-}
 
+    /// <summary>
+    /// Gets the module assembly (derived type's assembly).
+    /// </summary>
+    protected Assembly ModAssembly => GetType().Assembly;
+}

--- a/Common/UIX/UIBuilderExtensions.cs
+++ b/Common/UIX/UIBuilderExtensions.cs
@@ -8,8 +8,7 @@ internal static class UIBuilderExtensions
     internal static Button LocalButton(
         this UIBuilder ui,
         string label,
-        ButtonEventHandler localAction
-    )
+        ButtonEventHandler localAction)
     {
         var button = ui.Button(label);
         button.LocalPressed += localAction;

--- a/FluxLoopTweaks.Tests/AsyncWhile_RunAsync_PatchTests.cs
+++ b/FluxLoopTweaks.Tests/AsyncWhile_RunAsync_PatchTests.cs
@@ -22,8 +22,7 @@ public class AsyncWhile_RunAsync_PatchTests
         var shouldContinue = AsyncWhile_RunAsync_Patch.Prefix(
             mockAsyncWhile.Object,
             mockExecutionContext.Object,
-            ref result!
-        );
+            ref result!);
 
         // Assert
         Assert.True(shouldContinue);
@@ -42,8 +41,7 @@ public class AsyncWhile_RunAsync_PatchTests
         var shouldContinue = AsyncWhile_RunAsync_Patch.Prefix(
             mockAsyncWhile.Object,
             mockFrooxEngineContext.Object,
-            ref result!
-        );
+            ref result!);
 
         // Assert
         Assert.False(shouldContinue);

--- a/FluxLoopTweaks.Tests/FluxLoopTweaksModTests.cs
+++ b/FluxLoopTweaks.Tests/FluxLoopTweaksModTests.cs
@@ -56,15 +56,13 @@ public static class FluxLoopTweaksModTests
             .Should()
             .MatchRegex(
                 @"^\d+\.\d+\.\d+(?:\+[A-Za-z][A-Za-z0-9]*)?$",
-                "Version must be x.y.z with an optional +alpha suffix (no +hash allowed)"
-            );
+                "Version must be x.y.z with an optional +alpha suffix (no +hash allowed)");
     }
 
     [Theory]
     [InlineData(30000)] // デフォルト値
     public static void TimeoutMs_Should_Return_Expected_Value_When_Config_Is_Null(
-        int expectedTimeout
-    )
+        int expectedTimeout)
     {
         // Act
         var timeout = FluxLoopTweaksMod.TimeoutMs;
@@ -138,7 +136,6 @@ public static class FluxLoopTweaksModTests
         attribute
             .Should()
             .NotBeNull(
-                "internals should be visible to the test assembly so that private members can be tested"
-            );
+                "internals should be visible to the test assembly so that private members can be tested");
     }
 }

--- a/FluxLoopTweaks.Tests/While_Run_PatchTests.cs
+++ b/FluxLoopTweaks.Tests/While_Run_PatchTests.cs
@@ -41,8 +41,7 @@ public static class While_Run_PatchTests
     {
         var method = typeof(While_Run_Patch).GetMethod(
             "Prefix",
-            BindingFlags.Static | BindingFlags.NonPublic
-        );
+            BindingFlags.Static | BindingFlags.NonPublic);
         method.Should().NotBeNull();
         method!.ReturnType.Should().Be<bool>("Prefix method should return bool");
     }

--- a/FluxLoopTweaks/AsyncWhile_RunAsync_Patch.cs
+++ b/FluxLoopTweaks/AsyncWhile_RunAsync_Patch.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using FrooxEngine.ProtoFlux;
@@ -13,54 +14,11 @@ namespace EsnyaTweaks.FluxLoopTweaks;
 [HarmonyPatch(typeof(AsyncWhile), "RunAsync")]
 internal static class AsyncWhile_RunAsync_Patch
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static async Task<IOperation> RunAsync(
-        AsyncWhile instance,
-        FrooxEngineContext context,
-        ValueInput<bool> Condition,
-        AsyncCall LoopStart,
-        AsyncCall LoopIteration,
-        Continuation LoopEnd,
-        int timeout
-    )
-    {
-        await LoopStart.ExecuteAsync(context).ConfigureAwait(true);
-
-        var previousTick = context.Engine.UpdateTick;
-        var stopwatch = Stopwatch.StartNew();
-
-        while (Condition.Evaluate(context, defaultValue: false))
-        {
-            var currentTick = context.Engine.UpdateTick;
-            if (currentTick != previousTick)
-            {
-                stopwatch.Restart();
-            }
-            else if (stopwatch.ElapsedMilliseconds > timeout || context.AbortExecution)
-            {
-                ResoniteMod.Warn(
-                    $"AsyncWhile Timedout: {instance} ({stopwatch.ElapsedMilliseconds}ms)"
-                );
-                context.AbortExecution = true;
-                throw new ExecutionAbortedException(
-                    instance.Runtime as IExecutionRuntime,
-                    instance,
-                    LoopIteration.Target,
-                    isAsync: true
-                );
-            }
-            previousTick = currentTick;
-
-            await LoopIteration.ExecuteAsync(context).ConfigureAwait(true);
-        }
-        return LoopEnd.Target;
-    }
-
+    [SuppressMessage("Style", "SA1313", Justification = "Harmony magic parameters")]
     internal static bool Prefix(
         AsyncWhile __instance,
         ExecutionContext context,
-        ref Task<IOperation> __result
-    )
+        ref Task<IOperation> __result)
     {
         if (context is not FrooxEngineContext frooxEngineContext)
         {
@@ -74,8 +32,48 @@ internal static class AsyncWhile_RunAsync_Patch
             __instance.LoopStart,
             __instance.LoopIteration,
             __instance.LoopEnd,
-            FluxLoopTweaksMod.TimeoutMs
-        );
+            FluxLoopTweaksMod.TimeoutMs);
         return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static async Task<IOperation> RunAsync(
+        AsyncWhile instance,
+        FrooxEngineContext context,
+        ValueInput<bool> condition,
+        AsyncCall loopStart,
+        AsyncCall loopIteration,
+        Continuation loopEnd,
+        int timeout)
+    {
+        await loopStart.ExecuteAsync(context).ConfigureAwait(true);
+
+        var previousTick = context.Engine.UpdateTick;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (condition.Evaluate(context, defaultValue: false))
+        {
+            var currentTick = context.Engine.UpdateTick;
+            if (currentTick != previousTick)
+            {
+                stopwatch.Restart();
+            }
+            else if (stopwatch.ElapsedMilliseconds > timeout || context.AbortExecution)
+            {
+                ResoniteMod.Warn(
+                    $"AsyncWhile Timedout: {instance} ({stopwatch.ElapsedMilliseconds}ms)");
+                context.AbortExecution = true;
+                throw new ExecutionAbortedException(
+                    instance.Runtime as IExecutionRuntime,
+                    instance,
+                    loopIteration.Target,
+                    isAsync: true);
+            }
+            previousTick = currentTick;
+
+            await loopIteration.ExecuteAsync(context).ConfigureAwait(true);
+        }
+
+        return loopEnd.Target;
     }
 }

--- a/FluxLoopTweaks/FluxLoopTweaksMod.cs
+++ b/FluxLoopTweaks/FluxLoopTweaksMod.cs
@@ -19,7 +19,7 @@ public class FluxLoopTweaksMod : EsnyaResoniteMod
     [AutoRegisterConfigKey]
     private static readonly ModConfigurationKey<int> TimeoutKey = new(
         "Timeout",
-        "Timeout for in milliseconds.",
+        "Timeout in milliseconds.",
         computeDefault: () => 30_000);
 
     private static ModConfiguration? config;

--- a/FluxLoopTweaks/FluxLoopTweaksMod.cs
+++ b/FluxLoopTweaks/FluxLoopTweaksMod.cs
@@ -14,53 +14,53 @@ namespace EsnyaTweaks.FluxLoopTweaks;
 /// <inheritdoc/>
 public class FluxLoopTweaksMod : EsnyaResoniteMod
 {
-    private static Assembly ThisAssembly => typeof(FluxLoopTweaksMod).Assembly;
-
-    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
-
-    private static ModConfiguration? config;
-    private static readonly Harmony harmony = new(HarmonyId);
+    private static readonly Harmony Harmony = new(HarmonyId);
 
     [AutoRegisterConfigKey]
-    private static readonly ModConfigurationKey<int> timeoutKey = new(
+    private static readonly ModConfigurationKey<int> TimeoutKey = new(
         "Timeout",
         "Timeout for in milliseconds.",
-        computeDefault: () => 30_000
-    );
+        computeDefault: () => 30_000);
+
+    private static ModConfiguration? config;
 
     /// <summary>
     /// Gets the timeout value in milliseconds for loop operations.
     /// </summary>
-    public static int TimeoutMs => config?.GetValue(timeoutKey) ?? 30_000;
+    public static int TimeoutMs => config?.GetValue(TimeoutKey) ?? 30_000;
+
+    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
+
+    private static Assembly ThisAssembly => typeof(FluxLoopTweaksMod).Assembly;
+
+#if DEBUG
+    /// <summary>
+    /// Unpatches Harmony patches before hot reload.
+    /// </summary>
+    public static void BeforeHotReload()
+    {
+        Harmony.UnpatchAll(HarmonyId);
+    }
+
+    /// <summary>
+    /// Reapplies Harmony patches after hot reload.
+    /// </summary>
+    /// <param name="modInstance">The mod instance.</param>
+    public static void OnHotReload(ResoniteMod modInstance)
+    {
+        Harmony.PatchAll();
+        config = modInstance?.GetConfiguration();
+    }
+#endif
 
     /// <inheritdoc/>
     public override void OnEngineInit()
     {
-        Init(this);
+        Harmony.PatchAll();
+        config = GetConfiguration();
 
 #if DEBUG
         HotReloader.RegisterForHotReload(this);
 #endif
     }
-
-    private static void Init(ResoniteMod modInstance)
-    {
-        harmony.PatchAll();
-        config = modInstance?.GetConfiguration();
-    }
-
-#if DEBUG
-    /// <inheritdoc/>
-    public static void BeforeHotReload()
-    {
-        harmony.UnpatchAll(HarmonyId);
-    }
-
-    /// <inheritdoc/>
-    /// <param name="modInstance">The mod instance.</param>
-    public static void OnHotReload(ResoniteMod modInstance)
-    {
-        Init(modInstance);
-    }
-#endif
 }

--- a/FluxLoopTweaks/While_Run_Patch.cs
+++ b/FluxLoopTweaks/While_Run_Patch.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using FrooxEngine.ProtoFlux;
 using HarmonyLib;
 using ProtoFlux.Core;
@@ -10,7 +11,11 @@ namespace EsnyaTweaks.FluxLoopTweaks;
 [HarmonyPatch(typeof(While), "Run")]
 internal static class While_Run_Patch
 {
-    internal static bool Prefix(While __instance, ExecutionContext context, ref IOperation __result)
+    [SuppressMessage("Style", "SA1313", Justification = "Harmony magic parameters")]
+    internal static bool Prefix(
+        While __instance,
+        ExecutionContext context,
+        ref IOperation __result)
     {
         if (context is not FrooxEngineContext)
         {
@@ -24,19 +29,16 @@ internal static class While_Run_Patch
         {
             if (
                 stopwatch.ElapsedMilliseconds > FluxLoopTweaksMod.TimeoutMs
-                || context.AbortExecution
-            )
+                || context.AbortExecution)
             {
                 ResoniteMod.Warn(
-                    $"While Timedout: {__instance} ({stopwatch.ElapsedMilliseconds}ms)"
-                );
+                    $"While Timedout: {__instance} ({stopwatch.ElapsedMilliseconds}ms)");
                 context.AbortExecution = true;
                 throw new ExecutionAbortedException(
                     __instance.Runtime as IExecutionRuntime,
                     __instance,
                     __instance.LoopIteration.Target,
-                    isAsync: false
-                );
+                    isAsync: false);
             }
 
             __instance.LoopIteration.Execute(context);

--- a/InventoryUITweaks/InventoryUITweaksMod.cs
+++ b/InventoryUITweaks/InventoryUITweaksMod.cs
@@ -14,12 +14,6 @@ namespace EsnyaTweaks.InventoryUITweaks;
 /// <inheritdoc/>
 public class InventoryUITweaksMod : EsnyaResoniteMod
 {
-    private static Assembly ThisAssembly => typeof(InventoryUITweaksMod).Assembly;
-
-    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
-
-    private static readonly Harmony harmony = new(HarmonyId);
-
     /// <inheritdoc/>
     public override void OnEngineInit()
     {
@@ -38,11 +32,15 @@ public class InventoryUITweaksMod : EsnyaResoniteMod
     }
 
     /// <inheritdoc/>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Hot reload signature")]
-    public static void OnHotReload(ResoniteMod modInstance)
+    public static void OnHotReload(ResoniteMod _)
     {
         harmony.PatchAll();
     }
 #endif
 
+    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
+
+    private static Assembly ThisAssembly => typeof(InventoryUITweaksMod).Assembly;
+
+    private static readonly Harmony harmony = new(HarmonyId);
 }

--- a/InventoryUITweaks/Patches.cs
+++ b/InventoryUITweaks/Patches.cs
@@ -12,7 +12,8 @@ internal static class ReflectionCache
 {
     internal static readonly MethodInfo BrowserDialog_GoUp = AccessTools.Method(typeof(BrowserDialog), "GoUp", [typeof(int)]);
 
-    // Fields for runtime checks
+    internal static readonly FieldInfo? InventoryItemUI_Directory = GetInventoryItemUIDirectoryField();
+
     [SuppressMessage(
         "Globalization",
         "CA1303:Do not pass literals as localized parameters",
@@ -29,8 +30,6 @@ internal static class ReflectionCache
         }
         return field;
     }
-
-    internal static readonly FieldInfo? InventoryItemUI_Directory = GetInventoryItemUIDirectoryField();
 }
 
 // 1) Disable double-click requirement for the Back/Up button (always single press)
@@ -38,9 +37,7 @@ internal static class ReflectionCache
 [HarmonyPatch([typeof(UIBuilder), typeof(LocaleString)])]
 internal static class BrowserDialog_GenerateBackButton_Patch
 {
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Harmony patch method")]
-    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Harmony patch signature")]
-    private static bool Prefix(BrowserDialog __instance, UIBuilder ui, LocaleString label)
+    internal static bool Prefix(BrowserDialog __instance, UIBuilder ui, LocaleString label)
     {
         // Recreate original button without SyncDelegate callback and handle locally to avoid data-model target requirement
         var btn = ui.Button(in label, RadiantUI_Constants.Sub.RED);
@@ -57,8 +54,7 @@ internal static class BrowserDialog_GenerateBackButton_Patch
 [HarmonyPatch(typeof(BrowserItem), nameof(BrowserItem.Pressed))]
 internal static class BrowserItem_Pressed_Patch
 {
-    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Harmony patch signature")]
-    private static bool Prefix(BrowserItem __instance, IButton button, ButtonEventData eventData)
+    internal static bool Prefix(BrowserItem __instance)
     {
         // Single-click open only for folders (InventoryItemUI with non-null Directory)
         if (__instance is InventoryItemUI inv)
@@ -80,8 +76,7 @@ internal static class BrowserItem_Pressed_Patch
 internal static class InventoryBrowser_ProcessItem_Postfix
 {
     [HarmonyPostfix]
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Harmony patch method")]
-    private static void Postfix(InventoryItemUI item)
+    internal static void Postfix(InventoryItemUI item)
     {
         if (item == null)
         {
@@ -196,9 +191,7 @@ internal static class InventoryBrowser_ProcessItem_Postfix
 internal static class InventoryBrowser_OnItemSelected_Postfix
 {
     [HarmonyPostfix]
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Harmony patch method")]
-    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Harmony patch signature")]
-    private static void Postfix(InventoryBrowser __instance, BrowserItem previousItem, BrowserItem currentItem)
+    internal static void Postfix(InventoryBrowser __instance, BrowserItem _, BrowserItem currentItem)
     {
         var selected = currentItem as InventoryItemUI;
         var items = Pool.BorrowList<InventoryItemUI>();
@@ -233,8 +226,7 @@ internal static class InventoryBrowser_OnItemSelected_Postfix
 [HarmonyPatch]
 internal static class InventoryBrowser_BeginGeneratingNewDirectory_Patch
 {
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Harmony patch method")]
-    private static MethodInfo TargetMethod()
+    internal static MethodInfo TargetMethod()
     {
         return AccessTools.Method(
             typeof(InventoryBrowser),
@@ -249,8 +241,7 @@ internal static class InventoryBrowser_BeginGeneratingNewDirectory_Patch
     }
 
     [HarmonyPostfix]
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Harmony patch method")]
-    private static void Postfix(RecordDirectory directory, GridLayout folders)
+    internal static void Postfix(RecordDirectory directory, GridLayout folders)
     {
         if (directory != null || folders == null)
         {

--- a/LODGroupTweaks/LODGroupManager_FinalizeUpdate_Patch.cs
+++ b/LODGroupTweaks/LODGroupManager_FinalizeUpdate_Patch.cs
@@ -12,17 +12,14 @@ namespace EsnyaTweaks.LODGroupTweaks;
 [HarmonyPatch]
 internal static class LODGroupManager_FinalizeUpdate_Patch
 {
-
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used by Harmony via reflection")]
     [SuppressMessage("Performance", "CA1859", Justification = "Harmony requires MethodBase return type")]
-    private static MethodBase TargetMethod()
+    internal static MethodBase TargetMethod()
     {
         return AccessTools.Method(typeof(LODGroupManager), "FinalizeUpdate");
     }
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used by Harmony via reflection")]
     [SuppressMessage("Performance", "CA1859", Justification = "Harmony requires IEnumerable signature for transpilers")]
-    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
         var codes = new List<CodeInstruction>(instructions);
         try

--- a/PhotonDustTweaks/PhotonDustTweaksMod.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksMod.cs
@@ -11,27 +11,14 @@ namespace EsnyaTweaks.PhotonDustTweaks;
 /// <inheritdoc/>
 public class PhotonDustTweaksMod : EsnyaResoniteMod
 {
-    private static Assembly ThisAssembly => typeof(PhotonDustTweaksMod).Assembly;
-
-    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
-
-    //private static ModConfiguration? config;
-    private static readonly Harmony harmony = new(HarmonyId);
-
     /// <inheritdoc/>
     public override void OnEngineInit()
     {
-        Init(this);
+        Init();
 
 #if DEBUG
         HotReloader.RegisterForHotReload(this);
 #endif
-    }
-#pragma warning disable IDE0060 // Remove unused parameter
-    private static void Init(ResoniteMod modInstance)
-    {
-        harmony.PatchAll();
-        //config = modInstance?.GetConfiguration();
     }
 
 #if DEBUG
@@ -42,9 +29,20 @@ public class PhotonDustTweaksMod : EsnyaResoniteMod
     }
 
     /// <inheritdoc/>
-    public static void OnHotReload(ResoniteMod modInstance)
+    public static void OnHotReload(ResoniteMod _)
     {
-        Init(modInstance);
+        Init();
     }
 #endif
+
+    internal static string HarmonyId => $"com.nekometer.esnya.{ThisAssembly.GetName()}";
+
+    private static Assembly ThisAssembly => typeof(PhotonDustTweaksMod).Assembly;
+
+    private static readonly Harmony harmony = new(HarmonyId);
+
+    private static void Init()
+    {
+        harmony.PatchAll();
+    }
 }

--- a/UniLogTweaks/UniLog_Patch.cs
+++ b/UniLogTweaks/UniLog_Patch.cs
@@ -4,25 +4,9 @@ using HarmonyLib;
 
 namespace EsnyaTweaks.UniLogTweaks;
 
-#pragma warning disable IDE0060
-
 [HarmonyPatch(typeof(UniLog))]
 internal static class UniLog_Patch
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void Patch(ref string message, ref bool stackTrace, bool allowStackTrace)
-    {
-        if (UniLogTweaksMod.AddIndent)
-        {
-            message = message is null ? string.Empty : message.Replace("\n", "\n\t", System.StringComparison.Ordinal);
-        }
-
-        if (!allowStackTrace)
-        {
-            stackTrace = false;
-        }
-    }
-
     [HarmonyPatch(nameof(UniLog.Log), [typeof(string), typeof(bool)])]
     [HarmonyPrefix]
     internal static void Log_Prefix(ref string message, ref bool stackTrace)
@@ -42,5 +26,19 @@ internal static class UniLog_Patch
     internal static void Error_Prefix(ref string message, ref bool stackTrace)
     {
         Patch(ref message, ref stackTrace, !UniLogTweaksMod.AllowError);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Patch(ref string message, ref bool stackTrace, bool allowStackTrace)
+    {
+        if (UniLogTweaksMod.AddIndent)
+        {
+            message = message is null ? string.Empty : message.Replace("\n", "\n\t", System.StringComparison.Ordinal);
+        }
+
+        if (!allowStackTrace)
+        {
+            stackTrace = false;
+        }
     }
 }

--- a/docs/notes/stylecop-cleanup.md
+++ b/docs/notes/stylecop-cleanup.md
@@ -1,0 +1,19 @@
+# StyleCop Cleanup
+
+## Purpose
+Reduce StyleCop warnings by aligning common utilities with analyzer expectations.
+
+## Changes
+- Ensure files end with a single newline.
+- Order members from most to least accessible.
+- Place closing parentheses on the line of the last parameter.
+- Enable SA1111 to enforce closing-parenthesis placement.
+- Replace broad analyzer suppressions with signature or accessibility adjustments.
+- Suppress SA1313 for Harmony magic parameters (`__instance`, `__result`) where renaming is not viable.
+
+## Scope
+Entire solution.
+
+## Tests
+Existing unit tests cover affected helpers.
+


### PR DESCRIPTION
## Summary
- document reserved Harmony parameter names in AGENTS and StyleCop cleanup note
- refactor FluxLoopTweaks to satisfy StyleCop and compiler warnings

## Testing
- `dotnet format --verify-no-changes --no-restore --include FluxLoopTweaks/FluxLoopTweaksMod.cs FluxLoopTweaks/AsyncWhile_RunAsync_Patch.cs FluxLoopTweaks/While_Run_Patch.cs FluxLoopTweaks.Tests/AsyncWhile_RunAsync_PatchTests.cs FluxLoopTweaks.Tests/FluxLoopTweaksModTests.cs FluxLoopTweaks.Tests/While_Run_PatchTests.cs AGENTS.md docs/notes/stylecop-cleanup.md`
- `dotnet build -c Debug -v:minimal`
- `dotnet test -c Debug -v:minimal` *(fails: missing FrooxEngine and logger error)*

------
https://chatgpt.com/codex/tasks/task_e_68c54f52c07c832a9b3bc53f800b69b2