### PR TITLE
style: enforce error-level formatting and StyleCop rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,15 +23,14 @@ dotnet_diagnostic.SA1513.severity = none
 dotnet_diagnostic.SA1515.severity = none
 dotnet_diagnostic.SA1010.severity = none
 dotnet_diagnostic.SA1101.severity = none
-dotnet_diagnostic.SA1107.severity = none
 
 # Wrapping preferences
-csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_statements = false:error
 
 # Style preferences - use var instead of explicit type
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_elsewhere = true:error
 
 # Code analysis rules - Category-level settings (キツめ設定)
 dotnet_analyzer_diagnostic.category-design.severity = warning
@@ -41,7 +40,7 @@ dotnet_analyzer_diagnostic.category-maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-naming.severity = warning
 dotnet_analyzer_diagnostic.category-performance.severity = warning
 dotnet_analyzer_diagnostic.category-security.severity = warning
-dotnet_analyzer_diagnostic.category-style.severity = warning
+dotnet_analyzer_diagnostic.category-style.severity = error
 dotnet_analyzer_diagnostic.category-usage.severity = warning
 dotnet_analyzer_diagnostic.category-reliability.severity = warning
 
@@ -61,6 +60,10 @@ dotnet_diagnostic.IDE0058.severity = none    # Allow implicit discard of express
 dotnet_diagnostic.IDE0130.severity = error
 
 dotnet_diagnostic.CA1031.severity = none  # Mod should not throw exceptions to keep game running
+dotnet_diagnostic.CA1034.severity = none  # nested test helper is acceptable
+dotnet_diagnostic.CA1721.severity = none  # property name vs method for tests
+dotnet_diagnostic.CA1024.severity = none  # test exposure method
+dotnet_diagnostic.CA1515.severity = none  # internal visibility recommendations not needed
 
 
 # Tests Overrides
@@ -69,9 +72,9 @@ dotnet_diagnostic.CS1591.severity = none  # test classes often don't have XML co
 dotnet_diagnostic.CA1707.severity = none  # test classes often don't follow naming conventions
 
 # StyleCop: configure per rule (base off)
-dotnet_analyzer_diagnostic.category-StyleCop.severity = none
+dotnet_analyzer_diagnostic.category-StyleCop.severity = error
 dotnet_diagnostic.SA1649.severity = error
-dotnet_diagnostic.SA1111.severity = warning
+dotnet_diagnostic.SA1111.severity = error
 
 # StyleCop exclusions (repo policy)
 # - File header/element docs are not required; keep code concise
@@ -85,7 +88,6 @@ dotnet_diagnostic.SA1010.severity = none  # opening square brackets should not b
 dotnet_diagnostic.SA1200.severity = none  # using directives should appear within a namespace declaration
 dotnet_diagnostic.SA1210.severity = none  # using directives should be ordered alphabetically
 dotnet_diagnostic.SA1101.severity = none  # this. prefix
-dotnet_diagnostic.SA1107.severity = none  # multiple statements on one line
 dotnet_diagnostic.SA1202.severity = none  # member order rules
 dotnet_diagnostic.SA1311.severity = none  # static readonly fields casing
 dotnet_diagnostic.SA1009.severity = none  # closing parenthesis spacing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 - Prefer pure functions, immutability, and declarative style.
 - Good naming & structure > comments; comment only non-obvious WHY
 - Keep code self-explanatory.
+- Keep one statement per line (SA1107).
 - Order members from most to least accessible and ensure each file ends with exactly one trailing newline; place closing parentheses on the line of the last parameter.
 - Keep one type per file and place static members before instance members.
 - Avoid underscores in field or parameter names except for Harmony magic parameters.
@@ -79,9 +80,11 @@ The CI workflow uses static checks that do not require Resonite assemblies.
 - Warnings policy:
   - Zero-warnings baseline（Must）: タスク完了時は原則警告ゼロ。既存・新規とも修正し、抑制は最小限（やむを得ないシグネチャのみ）。
   - Prefer adjusting signatures or accessibility to eliminate warnings before using `SuppressMessage` or `#pragma`.
+  - Expose test-only members with `internal` and `[InternalsVisibleTo]` instead of suppressing `IDE0051`.
   - Harmony magic parameter names (e.g., `__instance`, `__result`) may use `[SuppressMessage("Style", "SA1313")]` with justification.
   - Globalization string warnings (`CA1303`) are disabled repository-wide; logs are English-only.
   - Condition debug-only `using` directives with `#if DEBUG` to avoid unused-using warnings in Release builds.
+  - Formatting/style analyzers are enforced as errors; difficult rules may be disabled individually (e.g., CA1034, CA1721, CA1024, CA1515).
 
 ## Pure Tests (Must)
 

--- a/AssetOptimizationTweaks/AssetOptimizationTweaksMod.cs
+++ b/AssetOptimizationTweaks/AssetOptimizationTweaksMod.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using EsnyaTweaks.Common.Modding;
+#if DEBUG
 using ResoniteModLoader;
+#endif
 
 [assembly: InternalsVisibleTo("EsnyaTweaks.AssetOptimizationTweaks.Tests")]
 

--- a/Common.PureTests/Common.PureTests.csproj
+++ b/Common.PureTests/Common.PureTests.csproj
@@ -9,15 +9,5 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <Import Project="..\Common\Common.Pure.projitems" Label="Shared" />
-  <ItemGroup>
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3.runner.inproc.console" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="FluentAssertions" />
-  </ItemGroup>
 </Project>
 

--- a/Common.PureTests/LogMessageTransformTests.cs
+++ b/Common.PureTests/LogMessageTransformTests.cs
@@ -16,4 +16,3 @@ public sealed class LogMessageTransformTests
         LogMessageTransform.ApplyIndent(input, addIndent).Should().Be(expected);
     }
 }
-

--- a/Common.PureTests/LoopTimeoutPolicyTests.cs
+++ b/Common.PureTests/LoopTimeoutPolicyTests.cs
@@ -16,4 +16,3 @@ public sealed class LoopTimeoutPolicyTests
             .Should().Be(expected);
     }
 }
-

--- a/Common.PureTests/OrderValidationPureTests.cs
+++ b/Common.PureTests/OrderValidationPureTests.cs
@@ -17,4 +17,3 @@ public sealed class OrderValidationPureTests
         OrderValidation.HasNonDescending(data).Should().Be(expected);
     }
 }
-

--- a/Common.Tests/EsnyaResoniteModTests.cs
+++ b/Common.Tests/EsnyaResoniteModTests.cs
@@ -19,15 +19,6 @@ public sealed class EsnyaResoniteModTests
         var asmName = typeof(DummyMod).Assembly.GetName().Name;
         id.Should().Contain(asmName);
     }
-    public sealed class DummyMod : EsnyaResoniteMod
-    {
-        public string HarmonyIdPublic => HarmonyId;
-
-        public void Auto(Action reg, Action unreg)
-        {
-            RegisterWithAutoUnregister(reg, unreg);
-        }
-    }
 }
 
 public sealed class EsnyaResoniteModAutoUnregisterTests
@@ -35,7 +26,7 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
     [Fact]
     public void RegisterWithAutoUnregister_Should_Invoke_Unregister_On_BeforeHotReload()
     {
-        var mod = new EsnyaResoniteModTests.DummyMod();
+        var mod = new DummyMod();
         var id = mod.HarmonyIdPublic;
         var called = 0;
         var regCalled = false;
@@ -56,7 +47,7 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
     [Fact]
     public void Multiple_Registers_Should_All_Unregister_On_BeforeHotReload()
     {
-        var mod = new EsnyaResoniteModTests.DummyMod();
+        var mod = new DummyMod();
         var id = mod.HarmonyIdPublic;
         var a = 0;
         var b = 0;
@@ -72,4 +63,14 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
 
     // NOTE: OnHotReload は内部で GetConfiguration() を呼ぶため、
     // テスト環境では Mod 初期化前例外となる。必要であれば別シナリオで検証する。
+}
+
+internal sealed class DummyMod : EsnyaResoniteMod
+{
+    public string HarmonyIdPublic => HarmonyId;
+
+    public void Auto(Action reg, Action unreg)
+    {
+        RegisterWithAutoUnregister(reg, unreg);
+    }
 }

--- a/Common.Tests/EsnyaResoniteModTests.cs
+++ b/Common.Tests/EsnyaResoniteModTests.cs
@@ -1,36 +1,32 @@
 using System;
-using System.Reflection;
 using FluentAssertions;
+using EsnyaTweaks.Common.Modding;
 using Xunit;
 
 namespace EsnyaTweaks.Common.Tests;
 
 public sealed class EsnyaResoniteModTests
 {
-    public sealed class DummyMod : Common.Modding.EsnyaResoniteMod
-    {
-        public string GetHarmonyId()
-        {
-            return HarmonyId;
-        }
-
-        public void Auto(Action reg, Action unreg)
-        {
-            RegisterWithAutoUnregister(reg, unreg);
-        }
-    }
-
     [Fact]
     public void HarmonyId_Should_Use_DefaultPrefix_And_AssemblyName()
     {
         var mod = new DummyMod();
-        var id = mod.GetHarmonyId();
+        var id = mod.HarmonyIdPublic;
 
         id.Should().NotBeNullOrEmpty();
         id.Should().StartWith("com.nekometer.esnya.");
 
         var asmName = typeof(DummyMod).Assembly.GetName().Name;
         id.Should().Contain(asmName);
+    }
+    public sealed class DummyMod : EsnyaResoniteMod
+    {
+        public string HarmonyIdPublic => HarmonyId;
+
+        public void Auto(Action reg, Action unreg)
+        {
+            RegisterWithAutoUnregister(reg, unreg);
+        }
     }
 }
 
@@ -40,7 +36,7 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
     public void RegisterWithAutoUnregister_Should_Invoke_Unregister_On_BeforeHotReload()
     {
         var mod = new EsnyaResoniteModTests.DummyMod();
-        var id = mod.GetHarmonyId();
+        var id = mod.HarmonyIdPublic;
         var called = 0;
         var regCalled = false;
 
@@ -48,12 +44,12 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
         regCalled.Should().BeTrue();
         called.Should().Be(0);
 
-        Common.Modding.EsnyaResoniteMod.BeforeHotReload(id);
+        EsnyaResoniteMod.BeforeHotReload(id);
 
         called.Should().Be(1);
 
         // 2回目は登録が消費されているため呼ばれない
-        Common.Modding.EsnyaResoniteMod.BeforeHotReload(id);
+        EsnyaResoniteMod.BeforeHotReload(id);
         called.Should().Be(1);
     }
 
@@ -61,13 +57,14 @@ public sealed class EsnyaResoniteModAutoUnregisterTests
     public void Multiple_Registers_Should_All_Unregister_On_BeforeHotReload()
     {
         var mod = new EsnyaResoniteModTests.DummyMod();
-        var id = mod.GetHarmonyId();
-        var a = 0; var b = 0;
+        var id = mod.HarmonyIdPublic;
+        var a = 0;
+        var b = 0;
 
         mod.Auto(() => { }, () => a++);
         mod.Auto(() => { }, () => b++);
 
-        Common.Modding.EsnyaResoniteMod.BeforeHotReload(id);
+        EsnyaResoniteMod.BeforeHotReload(id);
 
         a.Should().Be(1);
         b.Should().Be(1);

--- a/Common/Mod/EsnyaResoniteMod.cs
+++ b/Common/Mod/EsnyaResoniteMod.cs
@@ -155,9 +155,9 @@ public abstract class EsnyaResoniteMod : ResoniteMod
 
         register();
 
+#if DEBUG
         void Unregister()
         {
-#if DEBUG
             try
             {
                 HotReloader.RemoveMenuOption(category, optionName);
@@ -166,8 +166,12 @@ public abstract class EsnyaResoniteMod : ResoniteMod
             {
                 // ignore in tests or where hot reload lib is missing
             }
-#endif
         }
+#else
+        static void Unregister()
+        {
+        }
+#endif
 
         AutoUnregisters.AddOrUpdate(
             HarmonyId,

--- a/Common/Mod/EsnyaResoniteMod.cs
+++ b/Common/Mod/EsnyaResoniteMod.cs
@@ -169,16 +169,10 @@ public abstract class EsnyaResoniteMod : ResoniteMod
 #endif
         }
 
-        // Suppress IDE0028 suggestion to keep compatibility across analyzers and language levels.
-#pragma warning disable IDE0028
         AutoUnregisters.AddOrUpdate(
             HarmonyId,
-            _ => new List<Action> { Unregister },
-            (_, list) =>
-            {
-                list.Add(Unregister);
-                return list;
-            });
+            _ => [Unregister],
+            (_, list) => [.. list, Unregister]);
     }
 
     /// <summary>
@@ -196,13 +190,8 @@ public abstract class EsnyaResoniteMod : ResoniteMod
 
         AutoUnregisters.AddOrUpdate(
             HarmonyId,
-            _ => new List<Action> { unregister },
-            (_, list) =>
-            {
-                list.Add(unregister);
-                return list;
-            });
-#pragma warning restore IDE0028
+            _ => [unregister],
+            (_, list) => [.. list, unregister]);
     }
 
     private static void RunAutoUnregisters(string harmonyId)

--- a/FluxLoopTweaks/FluxLoopTweaksMod.cs
+++ b/FluxLoopTweaks/FluxLoopTweaksMod.cs
@@ -22,12 +22,9 @@ public class FluxLoopTweaksMod : EsnyaResoniteMod
     /// </summary>
     public static int TimeoutMs => config?.GetValue(TimeoutKey) ?? 30_000;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051", Justification = "Accessed via reflection by tests")]
-    private static new string HarmonyId => $"com.nekometer.esnya.{typeof(FluxLoopTweaksMod).Assembly.GetName()}";
+    internal static new string HarmonyId => $"com.nekometer.esnya.{typeof(FluxLoopTweaksMod).Assembly.GetName()}";
 
-#pragma warning disable SA1512 // Single-line comments should not be followed by blank line
-    // Use base HarmonyId for runtime behavior; static HarmonyId is for tests via reflection.
-#pragma warning restore SA1512 // Single-line comments should not be followed by blank line
+    // Use base HarmonyId for runtime behavior; static property is for tests.
 #if DEBUG
     /// <summary>
     /// Unpatches Harmony patches before hot reload.

--- a/InventoryUITweaks/InventoryUITweaksMod.cs
+++ b/InventoryUITweaks/InventoryUITweaksMod.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using EsnyaTweaks.Common.Modding;
+#if DEBUG
 using ResoniteModLoader;
+#endif
 
 [assembly: InternalsVisibleTo("EsnyaTweaks.InventoryUITweaks.Tests")]
 

--- a/LODGroupTweaks/LODGroupTweaksMod.cs
+++ b/LODGroupTweaks/LODGroupTweaksMod.cs
@@ -6,9 +6,8 @@ namespace EsnyaTweaks.LODGroupTweaks;
 /// <inheritdoc/>
 public class LODGroupTweaksMod : EsnyaResoniteMod
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051", Justification = "Accessed via reflection by tests")]
-    private static new string HarmonyId => $"com.nekometer.esnya.{typeof(LODGroupTweaksMod).Assembly.GetName()}";
-    // Use base HarmonyId for runtime behavior; static HarmonyId is for tests via reflection.
+    internal static new string HarmonyId => $"com.nekometer.esnya.{typeof(LODGroupTweaksMod).Assembly.GetName()}";
+    // Use base HarmonyId for runtime behavior; static property is for tests.
 #if DEBUG
     /// <summary>Unpatches all Harmony hooks before hot reload.</summary>
     public static void BeforeHotReload()

--- a/LODGroupTweaks/LODGroupTweaksMod.cs
+++ b/LODGroupTweaks/LODGroupTweaksMod.cs
@@ -1,5 +1,7 @@
 using EsnyaTweaks.Common.Modding;
+#if DEBUG
 using ResoniteModLoader;
+#endif
 
 namespace EsnyaTweaks.LODGroupTweaks;
 

--- a/PhotonDustTweaks/PhotonDustTweaksMod.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksMod.cs
@@ -1,5 +1,8 @@
+using System.Runtime.CompilerServices;
 using EsnyaTweaks.Common.Modding;
 using ResoniteModLoader;
+
+[assembly: InternalsVisibleTo("EsnyaTweaks.PhotonDustTweaks.Tests")]
 
 namespace EsnyaTweaks.PhotonDustTweaks;
 
@@ -8,10 +11,9 @@ namespace EsnyaTweaks.PhotonDustTweaks;
 /// </summary>
 public class PhotonDustTweaksMod : EsnyaResoniteMod
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051", Justification = "Accessed via reflection by tests")]
-    private static new string HarmonyId => HarmonyIdValue;
+    internal static new string HarmonyId => HarmonyIdValue;
 
-    // Use base HarmonyId for runtime behavior; static HarmonyId is for tests via reflection.
+    // Use base HarmonyId for runtime behavior; static property is for tests.
     private static string HarmonyIdValue =>
         $"com.nekometer.esnya.{typeof(PhotonDustTweaksMod).Assembly.GetName()}";
 

--- a/PhotonDustTweaks/PhotonDustTweaksMod.cs
+++ b/PhotonDustTweaks/PhotonDustTweaksMod.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using EsnyaTweaks.Common.Modding;
+#if DEBUG
 using ResoniteModLoader;
+#endif
 
 [assembly: InternalsVisibleTo("EsnyaTweaks.PhotonDustTweaks.Tests")]
 

--- a/SceneAuditor.Tests/DetectionPrimitivesTests.cs
+++ b/SceneAuditor.Tests/DetectionPrimitivesTests.cs
@@ -19,12 +19,9 @@ public sealed class DetectionPrimitivesTests
     [Fact]
     public void BuildDuplicateOwnersIndex_Should_Index_Duplicates()
     {
-        var a = "A";
-        var b = "B";
-        var c = "C";
-        var ab = new List<string> { a, b };
-        var bc = new List<string> { b, c };
-        var cOnly = new List<string> { c };
+        var ab = new List<string> { "A", "B" };
+        var bc = new List<string> { "B", "C" };
+        var cOnly = new List<string> { "C" };
         (string, IEnumerable<string>)[] groups =
         [
             ("G1", ab),
@@ -33,8 +30,8 @@ public sealed class DetectionPrimitivesTests
         ];
 
         var index = DetectionPrimitives.BuildDuplicateOwnersIndex(groups);
-        index[a].Should().HaveCount(1);
-        index[b].Should().HaveCount(2);
-        index[c].Should().HaveCount(2);
+        index["A"].Should().HaveCount(1);
+        index["B"].Should().HaveCount(2);
+        index["C"].Should().HaveCount(2);
     }
 }

--- a/SceneAuditor.Tests/DetectionPrimitivesTests.cs
+++ b/SceneAuditor.Tests/DetectionPrimitivesTests.cs
@@ -19,7 +19,9 @@ public sealed class DetectionPrimitivesTests
     [Fact]
     public void BuildDuplicateOwnersIndex_Should_Index_Duplicates()
     {
-        var a = "A"; var b = "B"; var c = "C";
+        var a = "A";
+        var b = "B";
+        var c = "C";
         var ab = new List<string> { a, b };
         var bc = new List<string> { b, c };
         var cOnly = new List<string> { c };

--- a/UniLogTweaks/UniLogTweaksMod.cs
+++ b/UniLogTweaks/UniLogTweaksMod.cs
@@ -1,5 +1,8 @@
+using System.Runtime.CompilerServices;
 using EsnyaTweaks.Common.Modding;
 using ResoniteModLoader;
+
+[assembly: InternalsVisibleTo("EsnyaTweaks.UniLogTweaks.Tests")]
 
 namespace EsnyaTweaks.UniLogTweaks;
 
@@ -21,10 +24,9 @@ public sealed class UniLogTweaksMod : EsnyaResoniteMod
     internal static bool AddIndent =>
         Config?.TryGetValue(AddIndentKey, out var value) != true || value;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051", Justification = "Accessed via reflection by tests")]
-    private static new string HarmonyId => HarmonyIdValue;
+    internal static new string HarmonyId => HarmonyIdValue;
 
-    // Use base HarmonyId.
+    // Use base HarmonyId for runtime behavior; static property is for tests.
     private static string HarmonyIdValue =>
         $"com.nekometer.esnya.{typeof(UniLogTweaksMod).Assembly.GetName()}";
 

--- a/docs/notes/stylecop-cleanup.md
+++ b/docs/notes/stylecop-cleanup.md
@@ -9,13 +9,19 @@ Reduce StyleCop warnings by aligning common utilities with analyzer expectations
 - Keep static members before instance members and limit each file to a single type.
 - Place closing parentheses on the line of the last parameter.
 - Enable SA1111 to enforce closing-parenthesis placement.
+- Enable SA1107 to require one statement per line.
+- Escalate formatting and StyleCop diagnostics to errors to maintain zero-warning baseline.
 - Replace broad analyzer suppressions with signature or accessibility adjustments.
+- Expose Harmony IDs as `internal` with `[InternalsVisibleTo]` instead of suppressing unused-member warnings.
 - Suppress SA1313 for Harmony magic parameters (`__instance`, `__result`) where renaming is not viable.
 - Avoid underscores in field or parameter names except for Harmony magic parameters.
 - Match file names with their first type to satisfy SA1649.
 - Apply `<inheritdoc/>` only when overriding or implementing base members.
 - Disable CA1303 (literal strings require localization) repository-wide and remove per-call suppressions.
+- Suppress CA1034, CA1721, CA1024, and CA1515 where structural changes would be excessive.
 - Wrap `using` directives needed only in debug builds in `#if DEBUG` blocks to silence Release warnings.
+- Rewrite transpilers to operate on enumerables directly, avoiding CA1859 and list allocations.
+- Use collection initializers with `ConcurrentDictionary.AddOrUpdate` to avoid `IDE0028` pragmas.
 
 ## Scope
 Entire solution.


### PR DESCRIPTION
## Summary
- treat format and StyleCop diagnostics as errors
- clean up tests and remove duplicate package references
- document analyzer policy
- expose Harmony IDs and refactor helpers to drop analyzer suppressions
- enable SA1107 and split multi-statement declarations

## Testing
- `dotnet format --verify-no-changes --no-restore`
- `dotnet build -c Debug -v:minimal`
- `dotnet test Common.PureTests/Common.PureTests.csproj -c Debug -v:minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c78e0e6158832a952ee3a681abc574